### PR TITLE
fix: return server only if weight > 0

### DIFF
--- a/roundrobin/rr.go
+++ b/roundrobin/rr.go
@@ -185,7 +185,7 @@ func (r *RoundRobin) nextServer() (*server, error) {
 			}
 		}
 		srv := r.servers[r.index]
-		if srv.weight >= r.currentWeight {
+		if srv.weight >= r.currentWeight && srv.weight > 0{
 			return srv, nil
 		}
 	}


### PR DESCRIPTION
This PR makes `nextServer` doesn't return server if the weight is 0.